### PR TITLE
fix(main.ts): Remove Devtools from production

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,12 +43,11 @@ import { JourneyModule } from './modules/journey/Journey.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ScheduledJobsModule } from '@/modules/scheduled-jobs/ScheduledJobs.module';
 import { DelayedMessageModule } from '@/common/core/delayed-message/DelayedMessage.module';
-import { DevtoolsModule } from '@nestjs/devtools-integration';
 @Module({
   imports: [
-    DevtoolsModule.register({
-      http: process.env.NODE_ENV !== 'production', // Enable HTTP integration in non-production environments
-    }),
+    // DevtoolsModule.register({
+    //   http: process.env.NODE_ENV !== 'production', // Enable HTTP integration in non-production environments
+    // }),
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env.development',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed HTTP DevTools module integration, streamlining the application module configuration. Development debugging utilities are no longer automatically loaded in non-production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->