### PR TITLE
List location bookings by location

### DIFF
--- a/src/common/dto/location-booking/GetAllBookingsAtLocationByDateRange.dto.ts
+++ b/src/common/dto/location-booking/GetAllBookingsAtLocationByDateRange.dto.ts
@@ -1,0 +1,7 @@
+import { CoreActionDto } from '@/common/dto/CoreAction.dto';
+
+export class GetAllBookingsAtLocationByDateRangeDto extends CoreActionDto {
+  locationId: string;
+  startDate: Date;
+  endDate: Date;
+}

--- a/src/common/dto/location-booking/GetAllBookingsAtLocationPaged.dto.ts
+++ b/src/common/dto/location-booking/GetAllBookingsAtLocationPaged.dto.ts
@@ -1,0 +1,8 @@
+import { PaginateQuery } from 'nestjs-paginate';
+
+export class GetAllBookingsAtLocationPagedDto {
+  query: PaginateQuery;
+  startDate: Date;
+  endDate: Date;
+  locationId: string;
+}

--- a/src/modules/location-booking/app/ILocationBookingQuery.service.ts
+++ b/src/modules/location-booking/app/ILocationBookingQuery.service.ts
@@ -1,10 +1,12 @@
 import { LocationBookingResponseDto } from '@/common/dto/location-booking/res/LocationBooking.response.dto';
 import { SearchBookingsByLocationDto } from '@/common/dto/location-booking/SearchBookingsByLocation.dto';
-import { PaginateConfig, Paginated } from 'nestjs-paginate';
+import { PaginateConfig, Paginated, PaginateQuery } from 'nestjs-paginate';
 import { LocationBookingEntity } from '@/modules/location-booking/domain/LocationBooking.entity';
 import { GetBookingByIdDto } from '@/common/dto/location-booking/GetBookingById.dto';
 import { GetBookedDatesByDateRangeDto } from '@/common/dto/location-booking/GetBookedDatesByDateRange.dto';
 import { BookedDatesResponseDto } from '@/common/dto/location-booking/res/BookedDate.response.dto';
+import { GetAllBookingsAtLocationByDateRangeDto } from '@/common/dto/location-booking/GetAllBookingsAtLocationByDateRange.dto';
+import { GetAllBookingsAtLocationPagedDto } from '@/common/dto/location-booking/GetAllBookingsAtLocationPaged.dto';
 
 export const ILocationBookingQueryService = Symbol(
   'ILocationBookingQueryService',
@@ -21,6 +23,10 @@ export interface ILocationBookingQueryService {
   getBookedDatesByDateRange(
     dto: GetBookedDatesByDateRangeDto,
   ): Promise<BookedDatesResponseDto>;
+
+  getAllBookingsAtLocationPaged(
+    dto: GetAllBookingsAtLocationPagedDto,
+  ): Promise<Paginated<LocationBookingResponseDto>>;
 }
 
 export namespace ILocationBookingQueryService_QueryConfig {

--- a/src/modules/location-booking/app/impl/LocationBookingQuery.service.ts
+++ b/src/modules/location-booking/app/impl/LocationBookingQuery.service.ts
@@ -6,7 +6,7 @@ import {
 import { Injectable } from '@nestjs/common';
 import { SearchBookingsByLocationDto } from '@/common/dto/location-booking/SearchBookingsByLocation.dto';
 import { LocationBookingResponseDto } from '@/common/dto/location-booking/res/LocationBooking.response.dto';
-import { paginate, Paginated } from 'nestjs-paginate';
+import { paginate, Paginated, PaginateQuery } from 'nestjs-paginate';
 import { LocationBookingRepository } from '@/modules/location-booking/infra/repository/LocationBooking.repository';
 import { GetBookingByIdDto } from '@/common/dto/location-booking/GetBookingById.dto';
 import { GetBookedDatesByDateRangeDto } from '@/common/dto/location-booking/GetBookedDatesByDateRange.dto';
@@ -15,6 +15,10 @@ import {
   BookedDatesResponseDto,
 } from '@/common/dto/location-booking/res/BookedDate.response.dto';
 import { LocationBookingDateRepository } from '@/modules/location-booking/infra/repository/LocationBookingDate.repository';
+import { GetAllBookingsAtLocationByDateRangeDto } from '@/common/dto/location-booking/GetAllBookingsAtLocationByDateRange.dto';
+import { LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { LocationBookingStatus } from '@/common/constants/LocationBookingStatus.constant';
+import { GetAllBookingsAtLocationPagedDto } from '@/common/dto/location-booking/GetAllBookingsAtLocationPaged.dto';
 
 @Injectable()
 export class LocationBookingQueryService
@@ -72,6 +76,7 @@ export class LocationBookingQueryService
         locationId: dto.locationId,
         startDate: dto.startDate,
         endDate: dto.endDate,
+        statuses: [LocationBookingStatus.PAYMENT_RECEIVED],
       })
       .then((results) => {
         const dates = results.map((result) => ({
@@ -81,5 +86,20 @@ export class LocationBookingQueryService
         const mappedDates = this.mapToArray(BookedDateResponseDto, dates);
         return this.mapTo(BookedDatesResponseDto, { dates: mappedDates });
       });
+  }
+
+  getAllBookingsAtLocationPaged(
+    dto: GetAllBookingsAtLocationPagedDto,
+  ): Promise<Paginated<LocationBookingResponseDto>> {
+    return paginate(dto.query, LocationBookingRepository(this.dataSource), {
+      ...ILocationBookingQueryService_QueryConfig.searchBookingsByLocation(),
+      where: {
+        locationId: dto.locationId,
+        dates: {
+          startDateTime: LessThanOrEqual(dto.endDate),
+          endDateTime: MoreThanOrEqual(dto.startDate),
+        },
+      },
+    }).then((res) => this.mapToPaginated(LocationBookingResponseDto, res));
   }
 }

--- a/src/modules/location-booking/infra/repository/LocationBooking.repository.ts
+++ b/src/modules/location-booking/infra/repository/LocationBooking.repository.ts
@@ -1,4 +1,4 @@
-import { DataSource, EntityManager } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { LocationBookingEntity } from '@/modules/location-booking/domain/LocationBooking.entity';
 
 export const LocationBookingRepository = (ctx: DataSource | EntityManager) =>

--- a/src/modules/location-booking/infra/repository/LocationBookingDate.repository.ts
+++ b/src/modules/location-booking/infra/repository/LocationBookingDate.repository.ts
@@ -12,12 +12,13 @@ export const LocationBookingDateRepository = (
         locationId: string;
         startDate: Date;
         endDate: Date;
+        statuses: LocationBookingStatus[];
       },
     ) {
       return this.createQueryBuilder('booking_date')
         .leftJoinAndSelect('booking_date.booking', 'booking')
-        .where('booking.status = :status', {
-          status: LocationBookingStatus.PAYMENT_RECEIVED,
+        .where('booking.status IN (:...statuses)', {
+          statuses: payload.statuses,
         })
         .andWhere('booking.locationId = :locationId', {
           locationId: payload.locationId,

--- a/src/modules/location-booking/interfaces/LocationBooking.owner.controller.ts
+++ b/src/modules/location-booking/interfaces/LocationBooking.owner.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Inject,
   Param,
+  ParseDatePipe,
   ParseUUIDPipe,
   Post,
   Query,
@@ -26,6 +27,7 @@ import { ILocationBookingManagementService } from '@/modules/location-booking/ap
 import { ProcessBookingDto } from '@/common/dto/location-booking/ProcessBooking.dto';
 import { GetBookedDatesByDateRangeDto } from '@/common/dto/location-booking/GetBookedDatesByDateRange.dto';
 import { BookedDatesResponseDto } from '@/common/dto/location-booking/res/BookedDate.response.dto';
+import { LocationBookingResponseDto } from '@/common/dto/location-booking/res/LocationBooking.response.dto';
 
 @ApiTags('Location Bookings')
 @ApiBearerAuth()
@@ -90,5 +92,24 @@ export class LocationBookingOwnerController {
     @Query() dto: GetBookedDatesByDateRangeDto,
   ): Promise<BookedDatesResponseDto> {
     return this.locationBookingQueryService.getBookedDatesByDateRange(dto);
+  }
+
+  @ApiOperation({ summary: 'Get all bookings at location paged' })
+  @ApiPaginationQuery(
+    ILocationBookingQueryService_QueryConfig.searchBookingsByLocation(),
+  )
+  @Get('/all-bookings-at-location-paged/:locationId')
+  getAllBookingsAtLocationPaged(
+    @Paginate() query: PaginateQuery,
+    @Param('locationId', ParseUUIDPipe) locationId: string,
+    @Query('startDate', new ParseDatePipe()) startDate: Date,
+    @Query('endDate', new ParseDatePipe()) endDate: Date,
+  ) {
+    return this.locationBookingQueryService.getAllBookingsAtLocationPaged({
+      query,
+      locationId,
+      startDate,
+      endDate,
+    });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a paginated endpoint to list all bookings at a location within a date range and updates booked-dates lookup to filter by multiple statuses.
> 
> - **API/Controller**:
>   - Add `GET /owner/location-bookings/all-bookings-at-location-paged/:locationId` accepting `startDate`, `endDate`, and pagination (`nestjs-paginate`).
> - **Application/Service**:
>   - Implement `getAllBookingsAtLocationPaged` in `LocationBookingQuery.service` using date-overlap filtering (`LessThanOrEqual`/`MoreThanOrEqual`) and pagination.
>   - Extend `getBookedDatesByDateRange` to pass `statuses` (uses `PAYMENT_RECEIVED`).
> - **Repository**:
>   - Update `LocationBookingDateRepository.findBookedDatesByDateRange` to accept `statuses: LocationBookingStatus[]` and filter with `IN (:...statuses)`.
> - **DTOs/Interfaces**:
>   - Add `GetAllBookingsAtLocationPagedDto` and wire into `ILocationBookingQueryService`.
>   - Introduce `GetAllBookingsAtLocationByDateRangeDto` (not used by new endpoint).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1808edb45e2c02f35ac0f7103a691ffeea10ff68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated booking retrieval endpoint for location owners to query bookings by date range and location with pagination support, enabling efficient browsing of large booking datasets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->